### PR TITLE
chore: update dependency versions for analyzer and custom_lint packages

### DIFF
--- a/packages/flutter_hooks_lint/CHANGELOG.md
+++ b/packages/flutter_hooks_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- update dependency versions for analyzer and custom_lint packages
+
 ## 1.3.0
 
 - Added support for newer Flutter versions

--- a/packages/flutter_hooks_lint/pubspec.yaml
+++ b/packages/flutter_hooks_lint/pubspec.yaml
@@ -15,8 +15,8 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  analyzer: ^7.3.0
-  custom_lint_builder: ^0.7.5
+  analyzer: ">=6.0.0"
+  custom_lint_builder: ">=0.6.0"
   # path: ^1.8.0
 dev_dependencies:
   lints: ^5.1.1

--- a/packages/flutter_hooks_lint/pubspec.yaml
+++ b/packages/flutter_hooks_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_hooks_lint
 description: A lint package providing guidelines for using flutter_hooks in your Flutter widget!
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/nikaera/flutter_hooks_lint
 repository: https://github.com/nikaera/flutter_hooks_lint
 documentation: https://github.com/nikaera/flutter_hooks_lint

--- a/packages/flutter_hooks_lint_flutter_test/pubspec.yaml
+++ b/packages/flutter_hooks_lint_flutter_test/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  custom_lint: ^0.7.5
-  custom_lint_core: ^0.7.5
+  custom_lint: ">=0.6.0"
+  custom_lint_core: ">=0.6.0"
   hooks_riverpod: ^2.4.10
   test: ^1.24.0
   flutter_hooks_lint:


### PR DESCRIPTION
This pull request includes updates to the dependency versions for the `analyzer` and `custom_lint` packages in the `flutter_hooks_lint` and `flutter_hooks_lint_flutter_test` packages.

Dependency updates:

* [`packages/flutter_hooks_lint/pubspec.yaml`](diffhunk://#diff-699af50b4bc5486119024b691b4630bf5ab46e07844e9d391d0f40569c9fc2aaL18-R19): Updated `analyzer` dependency to ">=6.0.0" and `custom_lint_builder` dependency to ">=0.6.0".
* [`packages/flutter_hooks_lint_flutter_test/pubspec.yaml`](diffhunk://#diff-86e4e6bb4aaa46239677f3f6a537e5b78edd00bb100943404185d2dac9fee796L13-R14): Updated `custom_lint` and `custom_lint_core` dependencies to ">=0.6.0".

Version bump:

* [`packages/flutter_hooks_lint/pubspec.yaml`](diffhunk://#diff-699af50b4bc5486119024b691b4630bf5ab46e07844e9d391d0f40569c9fc2aaL3-R3): Incremented package version from 1.3.0 to 1.3.1.

Changelog update:

* [`packages/flutter_hooks_lint/CHANGELOG.md`](diffhunk://#diff-0b4c29a445800f698cb929dbd33182931e206f9c9fbe84fab6a9ae80d751ecffR1-R4): Added entry for version 1.3.1, noting the update to dependency versions.