### PR TITLE
chore: update dependency constraints for analyzer and custom_lint pac…

### DIFF
--- a/packages/flutter_hooks_lint/pubspec.yaml
+++ b/packages/flutter_hooks_lint/pubspec.yaml
@@ -15,8 +15,8 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  analyzer: ">=6.0.0"
-  custom_lint_builder: ">=0.6.0"
+  analyzer: ">=6.0.0 <7.0.0"
+  custom_lint_builder: ">=0.6.0 <0.7.0"
   # path: ^1.8.0
 dev_dependencies:
   lints: ^5.1.1

--- a/packages/flutter_hooks_lint_flutter_test/pubspec.yaml
+++ b/packages/flutter_hooks_lint_flutter_test/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  custom_lint: ">=0.6.0"
-  custom_lint_core: ">=0.6.0"
+  custom_lint: ">=0.6.0 <0.7.0"
+  custom_lint_core: ">=0.6.0 <0.7.0"
   hooks_riverpod: ^2.4.10
   test: ^1.24.0
   flutter_hooks_lint:


### PR DESCRIPTION
This pull request includes updates to the dependency version constraints in the `pubspec.yaml` files for `flutter_hooks_lint` and `flutter_hooks_lint_flutter_test` packages.

Dependency version updates:

* [`packages/flutter_hooks_lint/pubspec.yaml`](diffhunk://#diff-699af50b4bc5486119024b691b4630bf5ab46e07844e9d391d0f40569c9fc2aaL18-R19): Updated version constraints for `analyzer` and `custom_lint_builder` dependencies to ensure compatibility with future versions.
* [`packages/flutter_hooks_lint_flutter_test/pubspec.yaml`](diffhunk://#diff-86e4e6bb4aaa46239677f3f6a537e5b78edd00bb100943404185d2dac9fee796L13-R14): Updated version constraints for `custom_lint` and `custom_lint_core` dependencies to ensure compatibility with future versions.…kages