### PR TITLE
feat: bump version to 1.4.0 and remove upper constraints for analyzer and custom_lint_builder

### DIFF
--- a/packages/flutter_hooks_lint/CHANGELOG.md
+++ b/packages/flutter_hooks_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+- Removed the upper version constraints for analyzer and custom_lint_builder dependencies.
+
 ## 1.3.1
 
 - update dependency versions for analyzer and custom_lint packages

--- a/packages/flutter_hooks_lint/pubspec.yaml
+++ b/packages/flutter_hooks_lint/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_hooks_lint
 description: A lint package providing guidelines for using flutter_hooks in your Flutter widget!
-version: 1.3.1
+version: 1.4.0
 homepage: https://github.com/nikaera/flutter_hooks_lint
 repository: https://github.com/nikaera/flutter_hooks_lint
 documentation: https://github.com/nikaera/flutter_hooks_lint
@@ -15,8 +15,8 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
-  analyzer: ">=6.0.0 <7.0.0"
-  custom_lint_builder: ">=0.6.0 <0.7.0"
+  analyzer: ">=6.0.0"
+  custom_lint_builder: ">=0.6.0"
   # path: ^1.8.0
 dev_dependencies:
   lints: ^5.1.1


### PR DESCRIPTION
This pull request updates the `flutter_hooks_lint` package to version 1.4.0, primarily to relax dependency constraints and allow for greater compatibility with future versions of its dependencies.

Dependency updates:

* Removed the upper version constraints for the `analyzer` and `custom_lint_builder` dependencies in `pubspec.yaml` to allow compatibility with newer versions.
* Updated the package version to `1.4.0` in `pubspec.yaml`.
* Added a changelog entry for version 1.4.0 describing the removal of upper version constraints.