### PR TITLE
chore: update Flutter version to 3.35.1 in CI workflow

### DIFF
--- a/.github/workflows/project-ci.yaml
+++ b/.github/workflows/project-ci.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.29.2"
+          flutter-version: "3.35.1"
           channel: "stable"
           cache: true
       - name: Install Flutter library


### PR DESCRIPTION
This pull request updates the Flutter version used in the GitHub Actions CI workflow to ensure the project builds and tests against the latest stable Flutter release.

Dependency update:

* [`.github/workflows/project-ci.yaml`](diffhunk://#diff-85170fb33d63d65a287d23c8d01b8d6639691b06e74b7ab91b90bcf918ed5b1cL38-R38): Upgraded the `flutter-version` from `3.29.2` to `3.35.1` in the CI workflow to use the latest stable Flutter SDK.